### PR TITLE
Fix PUSHPOW2 exponents

### DIFF
--- a/func/simple-subscription-plugin.fc
+++ b/func/simple-subscription-plugin.fc
@@ -3,13 +3,13 @@
 
 (int) slice_data_equal?(slice s1, slice s2) asm "SDEQ";
 
-int wallet_processing_amount() asm "23 PUSHPOW2";
+int wallet_processing_amount() asm "24 PUSHPOW2";
 int op:destruct() asm "0x64737472 PUSHINT";
 int op:payment_request() asm "0x706c7567 PUSHINT";
 int op:fallback() asm "0x756e6b77 PUSHINT";
 int op:subscription() asm "0x73756273 PUSHINT";
 int max_failed_attempts() asm "3 PUSHINT";
-int max_reserved_funds() asm "25 PUSHPOW2";
+int max_reserved_funds() asm "26 PUSHPOW2";
 
 ;; storage$_ wallet:MsgAddressInt
 ;;           beneficiary:MsgAddressInt


### PR DESCRIPTION
Fift assembler handles exponent encoding by itself